### PR TITLE
Update Kde packages

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -808,7 +808,7 @@ auto get_pkglist_desktop(const std::string_view& desktop_env) noexcept -> std::v
             "cachyos-nord-kde-theme-git", "cachyos-iridescent-kde", "cachyos-emerald-kde-theme-git",
             "cachyos-kde-settings", "cachyos-themes-sddm", "cachyos-wallpapers", "char-white", "dolphin", "egl-wayland", "gwenview",
             "konsole", "kate", "kdeconnect", "kscreen", "kde-gtk-config", "khotkeys", "kinfocenter",
-            "kinit", "kscreen", "kwallet-pam", "kwalletmanager", "plasma-wayland-protocols", "plasma-wayland-session",
+            "kinit", "kwallet-pam", "kwalletmanager", "plasma-wayland-protocols", "plasma-wayland-session",
             "plasma-desktop", "plasma-framework5", "plasma-nm", "plasma-pa", "plasma-workspace", "plasma-integration",
             "plasma-firewall", "plasma-browser-integration", "plasma-systemmonitor", "plasma-thunderbolt",
             "powerdevil", "ksysguard", "spectacle", "sddm", "sddm-kcm", "xsettingsd", "xdg-desktop-portal", "xdg-desktop-portal-kde"};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -811,7 +811,7 @@ auto get_pkglist_desktop(const std::string_view& desktop_env) noexcept -> std::v
             "kinit", "kwallet-pam", "kwalletmanager", "plasma-wayland-protocols", "plasma-wayland-session",
             "plasma-desktop", "plasma-framework5", "plasma-nm", "plasma-pa", "plasma-workspace", "plasma-integration",
             "plasma-firewall", "plasma-browser-integration", "plasma-systemmonitor", "plasma-thunderbolt",
-            "powerdevil", "ksysguard", "spectacle", "sddm", "sddm-kcm", "xsettingsd", "xdg-desktop-portal", "xdg-desktop-portal-kde"};
+            "powerdevil", "ksysguard", "spectacle", "sddm", "sddm-kcm", "xsettingsd", "xdg-desktop-portal", "xdg-desktop-portal-kde", "phonon-qt5-vlc"};
         /* clang-format on */
         pkg_list.insert(pkg_list.end(), std::move_iterator(to_be_inserted.begin()),
             std::move_iterator(to_be_inserted.end()));


### PR DESCRIPTION
- Remove duplicated packages
- Replace default phonon-gstreamer to phonon-vlc
    - phonon-vlc (this is the only maintained and supported Phonon backend for KDE apps that use Phonon for their multimedia needs; the alternative phonon-gstreamer has been unmaintained since 2013 and should not be shipped by default, or at all, ideally)
  source: https://community.kde.org/Distributions/Packaging_Recommendations