### PR TITLE
Add Limine bootloader support for UEFI

### DIFF
--- a/gucc/include/gucc/bootloader.hpp
+++ b/gucc/include/gucc/bootloader.hpp
@@ -103,8 +103,11 @@ auto refind_write_extra_kern_strings(std::string_view file_path, const std::vect
 // Installs & configures refind on system
 auto install_refind(const RefindInstallConfig& refind_install_config) noexcept -> bool;
 
-// Installs & configures limine on system
+// Installs Limine on system
 auto install_limine(const LimineInstallConfig& limine_install_config) noexcept -> bool;
+
+// Generate Limine config into system
+auto gen_limine_config(const std::vector<std::string>& kernel_params) noexcept -> std::string;
 
 }  // namespace gucc::bootloader
 

--- a/gucc/include/gucc/bootloader.hpp
+++ b/gucc/include/gucc/bootloader.hpp
@@ -67,6 +67,13 @@ struct GrubInstallConfig final {
     std::optional<std::string> bootloader_id{};
 };
 
+struct LimineInstallConfig final {
+    bool is_removable{};
+    std::string_view root_mountpoint;
+    std::string_view boot_mountpoint;
+    const std::vector<std::string>& kernel_params;
+};
+
 struct RefindInstallConfig final {
     bool is_removable{};
     std::string_view root_mountpoint;
@@ -95,6 +102,9 @@ auto refind_write_extra_kern_strings(std::string_view file_path, const std::vect
 
 // Installs & configures refind on system
 auto install_refind(const RefindInstallConfig& refind_install_config) noexcept -> bool;
+
+// Installs & configures limine on system
+auto install_limine(const LimineInstallConfig& limine_install_config) noexcept -> bool;
 
 }  // namespace gucc::bootloader
 

--- a/gucc/src/bootloader.cpp
+++ b/gucc/src/bootloader.cpp
@@ -357,6 +357,15 @@ auto install_refind(const RefindInstallConfig& refind_install_config) noexcept -
     return true;
 }
 
+auto gen_limine_config(const std::vector<std::string>& kernel_params) noexcept -> std::string {
+    const auto& kernel_params_str = utils::join(kernel_params, ' ');
+
+    std::string limine_config{};
+    limine_config += fmt::format(FMT_COMPILE("KERNEL_CMDLINE[default]=\"{}\"\n"), kernel_params_str);
+
+    return limine_config;
+}
+
 auto install_limine(const LimineInstallConfig& limine_install_config) noexcept -> bool {
     // Write generated config to system
     const auto& limine_config_path = fmt::format(FMT_COMPILE("{}/limine.conf"), limine_install_config.boot_mountpoint);
@@ -366,10 +375,9 @@ auto install_limine(const LimineInstallConfig& limine_install_config) noexcept -
     }
 
     // Write limine-entry-tool config to system
-    const auto& kernel_params_str = utils::join(limine_install_config.kernel_params, ' ');
-    std::string limine_config_content = fmt::format(FMT_COMPILE("KERNEL_CMDLINE[default]=\"{}\"\n"), kernel_params_str);
     const auto& limine_entry_tool_config_path = fmt::format(FMT_COMPILE("{}/etc/default/limine"), limine_install_config.root_mountpoint);
 
+    const auto& limine_config_content = bootloader::gen_limine_config(limine_install_config.kernel_params);
     if (!file_utils::create_file_for_overwrite(limine_entry_tool_config_path, limine_config_content)) {
         spdlog::error("Failed to open limine-entry-tool config for writing {}", limine_entry_tool_config_path);
         return false;

--- a/gucc/tests/meson.build
+++ b/gucc/tests/meson.build
@@ -103,6 +103,14 @@ executable(
   install: false)
 
 executable(
+  'test-limine_config_gen',
+  files('unit-limine_config_gen.cpp'),
+  dependencies: [deps, doctest],
+  link_with: [gucc_lib, doctest_main_lib],
+  include_directories: [include_directories('../include')],
+  install: false)
+
+executable(
   'test-refind_extra_kern_strings',
   files('unit-refind_extra_kern_strings.cpp'),
   dependencies: [deps, doctest],

--- a/gucc/tests/unit-limine_config_gen.cpp
+++ b/gucc/tests/unit-limine_config_gen.cpp
@@ -1,0 +1,92 @@
+#include "doctest_compatibility.h"
+
+#include "gucc/bootloader.hpp"
+#include "gucc/kernel_params.hpp"
+#include "gucc/logger.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <spdlog/sinks/callback_sink.h>
+#include <spdlog/spdlog.h>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+static constexpr auto LIMINE_CONFIG_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"
+)"sv;
+static constexpr auto LIMINE_CONFIG_SUBVOL_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw rootflags=subvol=/@ root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"
+)"sv;
+static constexpr auto LIMINE_CONFIG_SWAP_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f resume=UUID=59848b1b-c6be-48f4-b3e1-48179ea72dec"
+)"sv;
+static constexpr auto LIMINE_CONFIG_LUKS_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw cryptdevice=UUID=00e1b836-81b6-433f-83ca-0fd373e3cd50:luks_device root=/dev/mapper/luks_device"
+)"sv;
+static constexpr auto LIMINE_CONFIG_LUKS_SWAP_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw cryptdevice=UUID=00e1b836-81b6-433f-83ca-0fd373e3cd50:luks_device root=/dev/mapper/luks_device resume=/dev/mapper/luks_swap_device"
+)"sv;
+static constexpr auto LIMINE_CONFIG_ZFS_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw root=ZFS=zpcachyos/ROOT root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"
+)"sv;
+static constexpr auto LIMINE_CONFIG_LUKS_SUBVOL_TEST = R"(KERNEL_CMDLINE[default]="quiet splash rw rootflags=subvol=/@ cryptdevice=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f:luks-6bdb3301-8efb-4b84-b0b7-4caeef26fd6f root=/dev/mapper/luks-6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"
+)"sv;
+
+
+TEST_CASE("limine config gen test")
+{
+    auto callback_sink = std::make_shared<spdlog::sinks::callback_sink_mt>([](const spdlog::details::log_msg&) {
+        // noop
+    });
+    auto logger        = std::make_shared<spdlog::logger>("default", callback_sink);
+    spdlog::set_default_logger(logger);
+    gucc::logger::set_logger(logger);
+
+    SECTION("btrfs with subvolumes")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "rootflags=subvol=/@", "root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"};
+
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_SUBVOL_TEST);
+    }
+    SECTION("basic xfs")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_TEST);
+    }
+    SECTION("swap xfs")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f", "resume=UUID=59848b1b-c6be-48f4-b3e1-48179ea72dec"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_SWAP_TEST);
+    }
+    SECTION("luks xfs")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "cryptdevice=UUID=00e1b836-81b6-433f-83ca-0fd373e3cd50:luks_device", "root=/dev/mapper/luks_device"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_LUKS_TEST);
+    }
+    SECTION("luks swap xfs")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "cryptdevice=UUID=00e1b836-81b6-433f-83ca-0fd373e3cd50:luks_device", "root=/dev/mapper/luks_device", "resume=/dev/mapper/luks_swap_device"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_LUKS_SWAP_TEST);
+    }
+    SECTION("valid zfs")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "root=ZFS=zpcachyos/ROOT", "root=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_ZFS_TEST);
+    }
+    SECTION("luks btrfs with subvolumes")
+    {
+        const std::vector<std::string> kernel_params{
+            "quiet", "splash", "rw", "rootflags=subvol=/@", "cryptdevice=UUID=6bdb3301-8efb-4b84-b0b7-4caeef26fd6f:luks-6bdb3301-8efb-4b84-b0b7-4caeef26fd6f", "root=/dev/mapper/luks-6bdb3301-8efb-4b84-b0b7-4caeef26fd6f"};
+        const auto& limine_config_text = gucc::bootloader::gen_limine_config(kernel_params);
+        REQUIRE_EQ(limine_config_text, LIMINE_CONFIG_LUKS_SUBVOL_TEST);
+    }
+}

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -485,6 +485,19 @@ void install_refind() noexcept {
     std::this_thread::sleep_for(std::chrono::seconds(2));
 }
 
+void install_limine() noexcept {
+    static constexpr auto content = "\nThis installs Limine and configures it for Btrfs support.\nNo support for encrypted /boot.\n"sv;
+    const auto& do_install_uefi   = detail::yesno_widget(content, size(HEIGHT, LESS_THAN, 15) | size(WIDTH, LESS_THAN, 75));
+    /* clang-format off */
+    if (!do_install_uefi) { return; }
+    /* clang-format on */
+
+    utils::install_limine();
+
+    detail::infobox_widget("\nLimine was succesfully installed\n");
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+}
+
 void install_systemd_boot() noexcept {
     static constexpr auto content = "\nThis installs systemd-boot and generates boot entries\nfor the currently installed kernels.\nThis bootloader requires your kernels to be on the UEFI partition.\nThis is achieved by mounting the UEFI partition to /boot.\n"sv;
     const auto& do_install_uefi   = detail::yesno_widget(content, size(HEIGHT, LESS_THAN, 15) | size(WIDTH, LESS_THAN, 75));
@@ -512,11 +525,12 @@ void uefi_bootloader() noexcept {
     }
 #endif
 
-    static constexpr auto bootloaderInfo        = "Refind can be used standalone or in conjunction with other bootloaders as a graphical bootmenu.\nIt autodetects all bootable systems at boot time.\nGrub supports encrypted /boot partition and detects all bootable systems when you update your kernels.\nIt supports booting .iso files from a harddrive and automatic boot entries for btrfs snapshots.\nSystemd-boot is very light and simple and has little automation.\nIt autodetects windows, but is otherwise unsuited for multibooting."sv;
+    static constexpr auto bootloaderInfo        = "Refind can be used standalone or in conjunction with other bootloaders as a graphical bootmenu.\nIt autodetects all bootable systems at boot time.\nGrub supports encrypted /boot partition and detects all bootable systems when you update your kernels.\nIt supports booting .iso files from a harddrive and automatic boot entries for btrfs snapshots.\nSystemd-boot is very light and simple and has little automation.\nIt autodetects windows, but is otherwise unsuited for multibooting.\nLimine is lightweight bootloader with Btrfs snapshots loading support."sv;
     const std::vector<std::string> menu_entries = {
         "grub",
         "refind",
         "systemd-boot",
+        "limine"
     };
 
     auto screen = ScreenInteractive::Fullscreen();
@@ -536,6 +550,9 @@ void uefi_bootloader() noexcept {
             break;
         case 2:
             tui::install_systemd_boot();
+            break;
+        case 3:
+            tui::install_limine();
             break;
         }
         screen.ExitLoopClosure()();

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -40,6 +40,8 @@ void lvm_detect(std::optional<std::function<void()>> func_callback = std::nullop
 void umount_partitions() noexcept;
 void find_partitions() noexcept;
 
+[[nodiscard]] auto get_kernel_params() noexcept;
+[[nodiscard]] auto is_volume_removable() noexcept;
 [[nodiscard]] auto get_pkglist_base(const std::string_view& packages) noexcept -> std::optional<std::vector<std::string>>;
 [[nodiscard]] auto get_pkglist_desktop(const std::string_view& desktop) noexcept -> std::optional<std::vector<std::string>>;
 auto install_from_pkglist(const std::string_view& packages) noexcept -> bool;
@@ -49,6 +51,7 @@ void remove_pkgs(const std::string_view& packages) noexcept;
 void install_grub_uefi(const std::string_view& bootid, bool as_default = true) noexcept;
 void install_refind() noexcept;
 void install_systemd_boot() noexcept;
+void install_limine() noexcept;
 void uefi_bootloader(const std::string_view& bootloader) noexcept;
 void bios_bootloader(const std::string_view& bootloader) noexcept;
 void install_bootloader(const std::string_view& bootloader) noexcept;
@@ -133,7 +136,7 @@ inline std::size_t remove_all(std::string& inout, std::string_view what) noexcep
 constexpr inline auto bootloader_default_mount(std::string_view bootloader, std::string_view bios_mode) noexcept -> std::string_view {
     using namespace std::string_view_literals;
 
-    if (bootloader == "systemd-boot"sv || bios_mode == "BIOS"sv) {
+    if (bootloader == "systemd-boot"sv || bootloader == "limine"sv || bios_mode == "BIOS"sv) {
         return "/boot"sv;
     } else if (bootloader == "grub"sv || bootloader == "refind"sv) {
         return "/boot/efi"sv;
@@ -148,7 +151,7 @@ constexpr inline auto available_bootloaders(std::string_view bios_mode) noexcept
     if (bios_mode == "BIOS"sv) {
         return {"grub"sv};
     }
-    return {"systemd-boot"sv, "refind"sv, "grub"sv};
+    return {"systemd-boot"sv, "refind"sv, "grub"sv, "limine"sv};
 }
 
 }  // namespace utils


### PR DESCRIPTION
I haven't tested it yet, but I think it should work. Note that it includes some refactoring to make common functions shareable between refind and limine setups.