### PR TITLE
extend suppressions and add logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ CPMAddPackage(
   GIT_TAG "c++20"
   EXCLUDE_FROM_ALL YES
 )
+
+# Apply warning suppressions for FTXUI library targets
+suppress_ftxui_warnings()
+
 CPMAddPackage(
   NAME fmt
   GITHUB_REPOSITORY fmtlib/fmt
@@ -82,12 +86,6 @@ CPMAddPackage(
    GITHUB_REPOSITORY doctest/doctest
    GIT_TAG v2.4.11
    EXCLUDE_FROM_ALL YES
-)
-
-# FIXME(vnepogodin): temp hack for ftxui
-target_compile_options(screen PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated;-Wno-float-equal>
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
 )
 
 ##

--- a/gucc/include/gucc/zfs_types.hpp
+++ b/gucc/include/gucc/zfs_types.hpp
@@ -6,6 +6,7 @@
 #include <vector>    // for vector
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace gucc::fs {
 

--- a/meson.build
+++ b/meson.build
@@ -154,6 +154,7 @@ if not is_debug_build
    endif
 
    possible_cc_flags += ['-fdata-sections', '-ffunction-sections']
+   possible_link_flags = []
    if do_build_static
       possible_link_flags = ['-Wl,--gc-sections', '-static-libgcc', '-static-libstdc++']
    endif


### PR DESCRIPTION
Temporarily extend the compiler warnings suppression list to support GCC 15 (FTXUI requires an upgrade or upstream fixes). 

Also add debug logs for the partitions formatting workflow.
